### PR TITLE
Add ranked to FFA and TvT queues

### DIFF
--- a/src/main/java/cc/kasumi/practice/Practice.java
+++ b/src/main/java/cc/kasumi/practice/Practice.java
@@ -16,6 +16,7 @@ import cc.kasumi.practice.game.match.MatchManager;
 import cc.kasumi.practice.game.queue.*;
 import cc.kasumi.practice.game.queue.Queue;
 import cc.kasumi.practice.game.queue.type.FFAQueue;
+import cc.kasumi.practice.game.queue.type.PartyQueue;
 import cc.kasumi.practice.game.queue.type.SoloQueue;
 import cc.kasumi.practice.listener.*;
 import cc.kasumi.practice.nametag.NametagManager;
@@ -122,13 +123,13 @@ public final class Practice extends JavaPlugin {
             if (ladder.isRanked()) {
                 queues.put(ladderName + "_ranked", new SoloQueue(ladderName + "_ranked", ladder, true));
                 queues.put(ladderName + "_ffa_ranked", new FFAQueue(ladderName + "_ffa_ranked", ladder, true));
-                // Example: queues.put(ladderName + "_2v2_ranked", new PartyQueue(ladderName + "_2v2_ranked", ladder, true, 2));
+                queues.put(ladderName + "_2v2_ranked", new PartyQueue(ladderName + "_2v2_ranked", ladder, true, 2));
             }
 
             // Create unranked queues
             queues.put(ladderName + "_unranked", new SoloQueue(ladderName + "_unranked", ladder, false));
             queues.put(ladderName + "_ffa_unranked", new FFAQueue(ladderName + "_ffa_unranked", ladder, false));
-            // Example: queues.put(ladderName + "_2v2_unranked", new PartyQueue(ladderName + "_2v2_unranked", ladder, false, 2));
+            queues.put(ladderName + "_2v2_unranked", new PartyQueue(ladderName + "_2v2_unranked", ladder, false, 2));
         }
     }
 

--- a/src/main/java/cc/kasumi/practice/game/match/MatchManager.java
+++ b/src/main/java/cc/kasumi/practice/game/match/MatchManager.java
@@ -3,7 +3,9 @@ package cc.kasumi.practice.game.match;
 import cc.kasumi.practice.game.arena.Arena;
 import cc.kasumi.practice.game.ladder.Ladder;
 import cc.kasumi.practice.game.match.player.MatchPlayer;
+import cc.kasumi.practice.game.match.team.MatchTeam;
 import cc.kasumi.practice.game.match.team.SoloTeam;
+import cc.kasumi.practice.game.match.team.TeamImpl;
 import cc.kasumi.practice.game.match.type.FFAMatch;
 import cc.kasumi.practice.game.match.type.TvTMatch;
 import lombok.Getter;
@@ -44,8 +46,30 @@ public class MatchManager {
     }
 
     public void createTeamMatch(@NonNull List<Player> teamA, @NonNull List<Player> teamB, Ladder ladder, Arena arena, boolean ranked) {
-        // This method would be implemented for team matches (2v2, 3v3, etc.)
-        // For now, just throw an exception since it's not implemented
-        throw new UnsupportedOperationException("Team matches are not yet implemented");
+        if (teamA.isEmpty() || teamB.isEmpty()) {
+            throw new IllegalArgumentException("Both teams must have at least one player");
+        }
+        
+        if (teamA.size() != teamB.size()) {
+            throw new IllegalArgumentException("Teams must have equal number of players");
+        }
+
+        // Convert players to MatchPlayers for team A
+        List<MatchPlayer> matchPlayersA = teamA.stream()
+                .map(player -> new MatchPlayer(player.getUniqueId(), player.getName()))
+                .collect(Collectors.toList());
+
+        // Convert players to MatchPlayers for team B  
+        List<MatchPlayer> matchPlayersB = teamB.stream()
+                .map(player -> new MatchPlayer(player.getUniqueId(), player.getName()))
+                .collect(Collectors.toList());
+
+        // Create team objects
+        MatchTeam matchTeamA = new TeamImpl(matchPlayersA);
+        MatchTeam matchTeamB = new TeamImpl(matchPlayersB);
+
+        // Create the team match
+        Match match = new TvTMatch(MatchType.TEAM, ladder, arena, ranked, matchTeamA, matchTeamB);
+        matches.add(match);
     }
 }

--- a/src/main/java/cc/kasumi/practice/game/match/team/TeamImpl.java
+++ b/src/main/java/cc/kasumi/practice/game/match/team/TeamImpl.java
@@ -1,0 +1,48 @@
+package cc.kasumi.practice.game.match.team;
+
+import cc.kasumi.practice.game.match.player.MatchPlayer;
+import org.bukkit.entity.Player;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class TeamImpl implements MatchTeam {
+
+    private final List<MatchPlayer> players;
+
+    public TeamImpl(List<MatchPlayer> players) {
+        if (players == null || players.isEmpty()) {
+            throw new IllegalArgumentException("Team must have at least one player");
+        }
+        this.players = new ArrayList<>(players);
+    }
+
+    @Override
+    public int getAlive() {
+        return (int) players.stream().filter(player -> !player.isDead()).count();
+    }
+
+    @Override
+    public MatchPlayer getLeader() {
+        return players.get(0); // First player is the leader
+    }
+
+    @Override
+    public List<MatchPlayer> getPlayers() {
+        return new ArrayList<>(players);
+    }
+
+    @Override
+    public List<Player> getBukkitPlayers() {
+        List<Player> bukkitPlayers = new ArrayList<>();
+        
+        for (MatchPlayer matchPlayer : players) {
+            Player player = matchPlayer.getPlayer();
+            if (player != null) {
+                bukkitPlayers.add(player);
+            }
+        }
+        
+        return bukkitPlayers;
+    }
+}

--- a/src/main/java/cc/kasumi/practice/game/queue/QueueListener.java
+++ b/src/main/java/cc/kasumi/practice/game/queue/QueueListener.java
@@ -2,6 +2,7 @@ package cc.kasumi.practice.game.queue;
 
 import cc.kasumi.practice.menu.SelectFFAQueueMenu;
 import cc.kasumi.practice.menu.SelectQueueMenu;
+import cc.kasumi.practice.menu.SelectTvTQueueMenu;
 import cc.kasumi.practice.player.PlayerState;
 import cc.kasumi.practice.player.PracticePlayer;
 import cc.kasumi.practice.util.GameUtil;
@@ -57,6 +58,14 @@ public class QueueListener implements Listener {
 
         else if (clicked.equals(PlayerItem.FFA_UNRANKED_QUEUE.getItem())) {
             new SelectFFAQueueMenu(false).openMenu(player);
+        }
+
+        else if (clicked.equals(PlayerItem.TVT_RANKED_QUEUE.getItem())) {
+            new SelectTvTQueueMenu(true).openMenu(player);
+        }
+
+        else if (clicked.equals(PlayerItem.TVT_UNRANKED_QUEUE.getItem())) {
+            new SelectTvTQueueMenu(false).openMenu(player);
         }
 
         else if (clicked.equals(PlayerItem.LEAVE_QUEUE.getItem())) {

--- a/src/main/java/cc/kasumi/practice/menu/SelectTvTQueueMenu.java
+++ b/src/main/java/cc/kasumi/practice/menu/SelectTvTQueueMenu.java
@@ -1,0 +1,116 @@
+package cc.kasumi.practice.menu;
+
+import cc.kasumi.commons.menu.Button;
+import cc.kasumi.commons.menu.Menu;
+import cc.kasumi.commons.util.CC;
+import cc.kasumi.commons.util.ItemBuilder;
+import cc.kasumi.commons.util.TypeData;
+import cc.kasumi.practice.Practice;
+import cc.kasumi.practice.game.ladder.Ladder;
+import cc.kasumi.practice.game.queue.Queue;
+import cc.kasumi.practice.game.queue.QueuePlayer;
+import cc.kasumi.practice.game.queue.QueueType;
+import cc.kasumi.practice.game.queue.type.PartyQueue;
+import cc.kasumi.practice.player.PlayerState;
+import cc.kasumi.practice.player.PracticePlayer;
+import cc.kasumi.practice.util.GameUtil;
+import lombok.AllArgsConstructor;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.ClickType;
+import org.bukkit.inventory.ItemFlag;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import static cc.kasumi.practice.PracticeConfiguration.*;
+
+public class SelectTvTQueueMenu extends Menu {
+
+    private boolean ranked;
+
+    {
+        setAutoUpdate(true);
+    }
+
+    public SelectTvTQueueMenu(boolean ranked) {
+        this.ranked = ranked;
+    }
+
+    @Override
+    public String getTitle(Player player) {
+        return (this.ranked ? CC.GREEN + "Ranked" : CC.BLUE + "Unranked") + " TvT Queue";
+    }
+
+    @Override
+    public Map<Integer, Button> getButtons(Player player) {
+        Map<Integer, Button> buttons = new HashMap<>();
+
+        for (Queue queue : Practice.getInstance().getQueueManager().getQueues().values()) {
+            if (queue.getType() != QueueType.PARTY) continue;
+            if (queue.isRanked() != this.ranked) continue;
+
+            buttons.put(queue.getLadder().getDisplaySlot() - 1, new SelectTvTLadderButton((PartyQueue) queue));
+        }
+
+        return buttons;
+    }
+
+    @AllArgsConstructor
+    private class SelectTvTLadderButton extends Button {
+
+        private PartyQueue queue;
+
+        @Override
+        public ItemStack getButtonItem(Player player) {
+            Ladder ladder = queue.getLadder();
+            TypeData typeData = ladder.getDisplayType();
+
+            return new ItemBuilder(
+                    typeData.getType(), typeData.getData()).
+                    name(MAIN_COLOR + ladder.getDisplayName() + " " + queue.getPartySize() + "v" + queue.getPartySize()).
+                    lore(Arrays.asList(
+                            CC.YELLOW + "Right click to join TvT queue",
+                            "",
+                            CC.GRAY + "Queue status: " + CC.WHITE + queue.getQueueStatus(),
+                            CC.GRAY + "Minimum players: " + CC.WHITE + queue.getMinPlayers(),
+                            "",
+                            queue.getReadyStatusMessage()
+                    )).
+                    flag(ItemFlag.HIDE_POTION_EFFECTS).build();
+        }
+
+        @Override
+        public void clicked(Player player, ClickType clickType) {
+            PracticePlayer practicePlayer = PracticePlayer.getPracticePlayer(player.getUniqueId());
+
+            if (practicePlayer == null) {
+                return;
+            }
+
+            if (practicePlayer.isInMatch()) {
+                player.sendMessage(ERROR_COLOR + "You cannot queue while in match");
+                return;
+            }
+
+            if (queue.isFull()) {
+                player.sendMessage(ERROR_COLOR + "This TvT queue is currently full!");
+                return;
+            }
+
+            player.closeInventory();
+
+            queue.addPlayer(new QueuePlayer(player.getUniqueId()));
+            practicePlayer.setPlayerState(PlayerState.QUEUEING);
+            practicePlayer.setCurrentQueue(queue);
+
+            String queueType = queue.isRanked() ? "ranked " : "unranked ";
+            player.sendMessage(MAIN_COLOR + "Added you to " + queueType + SEC_COLOR + queue.getLadder().getDisplayName() +
+                    MAIN_COLOR + " " + queue.getPartySize() + "v" + queue.getPartySize() + " queue! " + 
+                    SEC_COLOR + "(" + queue.getQueueStatus() + ")");
+
+            player.getInventory().setContents(GameUtil.getQueueContents());
+        }
+    }
+}

--- a/src/main/java/cc/kasumi/practice/util/GameUtil.java
+++ b/src/main/java/cc/kasumi/practice/util/GameUtil.java
@@ -8,13 +8,13 @@ public class GameUtil {
         return new ItemStack[] {
                 PlayerItem.KIT_EDITOR.getItem(),
                 null,
-                null,
-                null,
-                null,
-                null,
                 PlayerItem.UNRANKED_QUEUE.getItem(),
+                PlayerItem.RANKED_QUEUE.getItem(),
+                null,
                 PlayerItem.FFA_UNRANKED_QUEUE.getItem(),
-                PlayerItem.RANKED_QUEUE.getItem()
+                PlayerItem.FFA_RANKED_QUEUE.getItem(),
+                PlayerItem.TVT_UNRANKED_QUEUE.getItem(),
+                PlayerItem.TVT_RANKED_QUEUE.getItem()
         };
     }
 

--- a/src/main/java/cc/kasumi/practice/util/PlayerItem.java
+++ b/src/main/java/cc/kasumi/practice/util/PlayerItem.java
@@ -34,6 +34,16 @@ public enum PlayerItem {
             name(CC.BLUE + "Unranked FFA Queue").
             lore(CC.YELLOW + "Right click to join FFA queue")),
 
+    TVT_RANKED_QUEUE(new ItemBuilder(
+            Material.DIAMOND_PICKAXE).
+            name(CC.GREEN + "Ranked TvT Queue").
+            lore(CC.YELLOW + "Right click to join team queue")),
+
+    TVT_UNRANKED_QUEUE(new ItemBuilder(
+            Material.IRON_PICKAXE).
+            name(CC.BLUE + "Unranked TvT Queue").
+            lore(CC.YELLOW + "Right click to join team queue")),
+
     LEAVE_QUEUE(new ItemBuilder(
             Material.REDSTONE).
             name(CC.RED + "Leave Queue").


### PR DESCRIPTION
Add full support for TvT ranked and unranked queues and expose FFA ranked queues in the lobby.

---
<a href="https://cursor.com/background-agent?bcId=bc-703b5e11-0d3a-4f99-8842-cf9c96430fff">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-703b5e11-0d3a-4f99-8842-cf9c96430fff">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>